### PR TITLE
Implement structure for quotas and functional testing

### DIFF
--- a/.github/workflows/test-py39-functional.yaml
+++ b/.github/workflows/test-py39-functional.yaml
@@ -1,0 +1,46 @@
+name: test-py39-functional
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+
+      - name: Install ColdFront and plugin
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Install and start Microstack
+        run: |
+          sudo snap install microstack --beta --devmode
+          sudo microstack init --auto --control
+          microstack.openstack domain create sso
+          microstack.openstack identity provider create sso --domain sso
+          microstack.openstack mapping create sso_mapping --rules ci/mapping.json
+          microstack.openstack federation protocol create openid --identity-provider sso --mapping sso_mapping
+
+      - name: Run functional tests
+        run: |
+          export DJANGO_SETTINGS_MODULE="local_settings"
+          export FUNCTIONAL_TESTS="True"
+          export CREDENTIAL_NAME=$(openssl rand -base64 12)
+          export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_SECRET=$(
+              microstack.openstack application credential create "$CREDENTIAL_NAME" -f value -c secret)
+          export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID=$(
+              microstack.openstack application credential show "$CREDENTIAL_NAME" -f value -c id)
+
+          coldfront test coldfront_plugin_openstack.tests.functional

--- a/ci/mapping.json
+++ b/ci/mapping.json
@@ -1,0 +1,16 @@
+[
+    {
+        "local": [
+            {
+                "user": {
+                    "name": "{0}"
+                }
+            }
+        ],
+        "remote": [
+            {
+                "type": "OIDC-preferred_username"
+            }
+        ]
+    }
+]

--- a/ci/run_functional_tests.sh
+++ b/ci/run_functional_tests.sh
@@ -15,3 +15,5 @@ export DJANGO_SETTINGS_MODULE="local_settings"
 export FUNCTIONAL_TESTS="True"
 
 coldfront test coldfront_plugin_openstack.tests.functional
+
+microstack.openstack application credential delete $OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID

--- a/ci/run_functional_tests.sh
+++ b/ci/run_functional_tests.sh
@@ -1,0 +1,17 @@
+# Creates the appropriate credentials and runs tests
+#
+# Tests expect the resource to be name Devstack
+openstack_cmd="microstack.openstack"
+credential_name=$(openssl rand -base64 12)
+
+export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_SECRET=$(
+    $openstack_cmd application credential create "$credential_name" -f value -c secret)
+export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID=$(
+    $openstack_cmd application credential show "$credential_name" -f value -c id)
+
+source /tmp/coldfront_venv/bin/activate
+
+export DJANGO_SETTINGS_MODULE="local_settings"
+export FUNCTIONAL_TESTS="True"
+
+coldfront test coldfront_plugin_openstack.tests.functional

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -12,9 +12,9 @@ $openstack_cmd mapping create sso_mapping --rules ci/mapping.json
 $openstack_cmd federation protocol create openid --identity-provider sso --mapping sso_mapping
 
 sudo apt-get update
-sudo apt-get install -y python3-pip python3-virtualenv
+sudo apt-get install -y python3-pip python3-virtualenv python3.9
 
-virtualenv -p python3 /tmp/coldfront_venv
+virtualenv -p python3.9 /tmp/coldfront_venv
 source /tmp/coldfront_venv/bin/activate
 
 pip3 install -r requirements.txt

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,0 +1,21 @@
+# Installs and starts Microstack on a Ubuntu system
+# Only run once.
+
+openstack_cmd="microstack.openstack"
+
+sudo snap install microstack --beta --devmode
+sudo microstack init --auto --control
+
+$openstack_cmd domain create sso
+$openstack_cmd identity provider create sso --domain sso
+$openstack_cmd mapping create sso_mapping --rules ci/mapping.json
+$openstack_cmd federation protocol create openid --identity-provider sso --mapping sso_mapping
+
+sudo apt-get update
+sudo apt-get install -y python3-pip python3-virtualenv
+
+virtualenv -p python3 /tmp/coldfront_venv
+source /tmp/coldfront_venv/bin/activate
+
+pip3 install -r requirements.txt
+pip3 install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     coldfront @ git+https://github.com/ubccr/coldfront#egg=coldfront
     python-cinderclient

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()

--- a/src/coldfront_plugin_openstack/attributes.py
+++ b/src/coldfront_plugin_openstack/attributes.py
@@ -1,0 +1,33 @@
+RESOURCE_AUTH_URL = 'OpenStack Auth URL'
+RESOURCE_FEDERATION_PROTOCOL = 'OpenStack Federation Protocol'
+RESOURCE_IDP = 'OpenStack Identity Provider'
+RESOURCE_PROJECT_DOMAIN = 'OpenStack Domain for Projects'
+RESOURCE_ROLE = 'OpenStack Role for User in Project'
+RESOURCE_USER_DOMAIN = 'OpenStack Domain for Users'
+
+RESOURCE_ATTRIBUTES = [RESOURCE_AUTH_URL,
+                       RESOURCE_FEDERATION_PROTOCOL,
+                       RESOURCE_IDP,
+                       RESOURCE_PROJECT_DOMAIN,
+                       RESOURCE_ROLE,
+                       RESOURCE_USER_DOMAIN]
+
+ALLOCATION_PROJECT_ID = 'OpenStack Project ID'
+ALLOCATION_PROJECT_NAME = 'OpenStack Project Name'
+
+ALLOCATION_ATTRIBUTES = [ALLOCATION_PROJECT_ID,
+                         ALLOCATION_PROJECT_NAME]
+
+QUOTA_INSTANCES = 'OpenStack Compute Instance Quota'
+QUOTA_RAM = 'OpenStack Compute RAM Quota'
+QUOTA_VCPU = 'OpenStack Compute vCPU Quota'
+
+QUOTA_VOLUMES = 'OpenStack Volume Quota'
+QUOTA_VOLUMES_GB = 'OpenStack Volume GB Quota'
+
+ALLOCATION_QUOTA_ATTRIBUTES = [QUOTA_INSTANCES,
+                               QUOTA_RAM,
+                               QUOTA_VCPU,
+                               QUOTA_VOLUMES,
+                               QUOTA_VOLUMES_GB]
+

--- a/src/coldfront_plugin_openstack/management/commands/add_openstack_resource.py
+++ b/src/coldfront_plugin_openstack/management/commands/add_openstack_resource.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
                             help='Role for user when added to project (default: member)')
 
     def handle(self, *args, **options):
-        openstack = Resource.objects.get_or_create(
+        openstack, _ = Resource.objects.get_or_create(
             resource_type=ResourceType.objects.get(name='OpenStack'),
             parent_resource=None,
             name=options['name'],
@@ -75,13 +75,13 @@ class Command(BaseCommand):
             resource=openstack,
             value=options['role']
         )
-        ResourceAttribute.object.get_or_create(
+        ResourceAttribute.objects.get_or_create(
             resource_attribute_type=ResourceAttributeType.objects.get(
                 name='quantity_label'),
             resource=openstack,
             value='Units of computing to allocate to the project. 1 Unit = 1 Instance, 2 vCPU, 4G RAM'
         )
-        ResourceAttribute.object.get_or_create(
+        ResourceAttribute.objects.get_or_create(
             resource_attribute_type=ResourceAttributeType.objects.get(
                 name='quantity_default_value'),
             resource=openstack,

--- a/src/coldfront_plugin_openstack/management/commands/add_openstack_resource.py
+++ b/src/coldfront_plugin_openstack/management/commands/add_openstack_resource.py
@@ -6,6 +6,8 @@ from coldfront.core.resource.models import (Resource,
                                             ResourceAttributeType,
                                             ResourceType)
 
+from coldfront_plugin_openstack import attributes
+
 
 class Command(BaseCommand):
     help = 'Create OpenStack resource'
@@ -39,37 +41,37 @@ class Command(BaseCommand):
 
         ResourceAttribute.objects.get_or_create(
             resource_attribute_type=ResourceAttributeType.objects.get(
-                name='OpenStack Auth URL'),
+                name=attributes.RESOURCE_AUTH_URL),
             resource=openstack,
             value=options['auth-url']
         )
         ResourceAttribute.objects.get_or_create(
             resource_attribute_type=ResourceAttributeType.objects.get(
-                name='OpenStack Domain for Projects'),
+                name=attributes.RESOURCE_PROJECT_DOMAIN),
             resource=openstack,
             value=options['projects-domain']
         )
         ResourceAttribute.objects.get_or_create(
             resource_attribute_type=ResourceAttributeType.objects.get(
-                name='OpenStack Domain for Users'),
+                name=attributes.RESOURCE_USER_DOMAIN),
             resource=openstack,
             value=options['users-domain']
         )
         ResourceAttribute.objects.get_or_create(
             resource_attribute_type=ResourceAttributeType.objects.get(
-                name='OpenStack Identity Provider'),
+                name=attributes.RESOURCE_IDP),
             resource=openstack,
             value=options['idp']
         )
         ResourceAttribute.objects.get_or_create(
             resource_attribute_type=ResourceAttributeType.objects.get(
-                name='OpenStack Federation Protocol'),
+                name=attributes.RESOURCE_FEDERATION_PROTOCOL),
             resource=openstack,
             value=options['protocol']
         )
         ResourceAttribute.objects.get_or_create(
             resource_attribute_type=ResourceAttributeType.objects.get(
-                name='OpenStack Role for User in Project'),
+                name=attributes.RESOURCE_ROLE),
             resource=openstack,
             value=options['role']
         )

--- a/src/coldfront_plugin_openstack/management/commands/register_openstack_attributes.py
+++ b/src/coldfront_plugin_openstack/management/commands/register_openstack_attributes.py
@@ -1,42 +1,36 @@
 from django.core.management.base import BaseCommand
-from django.core.management import call_command
 
 from coldfront.core.allocation import models as allocation_models
 from coldfront.core.resource import models as resource_models
+
+from coldfront_plugin_openstack import attributes
 
 
 class Command(BaseCommand):
     help = 'Add default OpenStack allocation related choices'
 
     def register_allocation_attributes(self):
-        for name, attribute_type, has_usage, is_private in (
-                ('OpenStack Compute Instance Quota', 'Int', False, False),
-                ('OpenStack Compute RAM Quota', 'Int', False, False),
-                ('OpenStack Compute vCPU Quota', 'Int', False, False),
-                ('OpenStack Project ID', 'Text', False, False),
-                ('OpenStack Project Name', 'Text', False, False),
-        ):
+        def register(attribute_name, attribute_type):
             allocation_models.AllocationAttributeType.objects.get_or_create(
-                name=name,
+                name=attribute_name,
                 attribute_type=allocation_models.AttributeType.objects.get(
                     name=attribute_type),
-                has_usage=has_usage,
-                is_private=is_private
+                has_usage=False,
+                is_private=False
             )
 
+        for allocation_attribute in attributes.ALLOCATION_ATTRIBUTES:
+            register(allocation_attribute, 'Text')
+
+        for allocation_quota_attribute in attributes.ALLOCATION_QUOTA_ATTRIBUTES:
+            register(allocation_quota_attribute, 'Int')
+
     def register_resource_attributes(self):
-        for resource_attribute_type, attribute_type in (
-            ('OpenStack Auth URL', 'Text'),
-            ('OpenStack Domain for Projects', 'Text'),
-            ('OpenStack Domain for Users', 'Text'),
-            ('OpenStack Federation Protocol', 'Text'),
-            ('OpenStack Identity Provider', 'Text'),
-            ('OpenStack Role for User in Project', 'Text'),
-        ):
+        for resource_attribute_type in attributes.RESOURCE_ATTRIBUTES:
             resource_models.ResourceAttributeType.objects.get_or_create(
                 name=resource_attribute_type,
                 attribute_type=resource_models.AttributeType.objects.get(
-                    name=attribute_type)
+                    name='Text')
             )
 
     def register_resource_type(self):

--- a/src/coldfront_plugin_openstack/tasks.py
+++ b/src/coldfront_plugin_openstack/tasks.py
@@ -16,13 +16,13 @@ from coldfront_plugin_openstack import (attributes,
 
 
 NOVA_VERSION = '2'
-
 NOVA_KEY_MAPPING = {
     attributes.QUOTA_INSTANCES: 'instances',
     attributes.QUOTA_VCPU: 'cores',
     attributes.QUOTA_RAM: 'ram',
 }
 
+CINDER_VERSION = '3'
 CINDER_KEY_MAPPING = {
     attributes.QUOTA_VOLUMES: 'volumes',
     attributes.QUOTA_VOLUMES_GB: 'gigabytes',
@@ -120,7 +120,8 @@ def activate_allocation(allocation_pk):
         compute.quotas.update(openstack_project.id, **nova_payload)
 
     def set_cinder_quota():
-        storage = cinderclient.Client('3', session=get_session_for_resource(resource))
+        storage = cinderclient.Client(CINDER_VERSION,
+                                      session=get_session_for_resource(resource))
         cinder_payload = {
             cinder_key: allocation.get_attribute(key)
             if allocation.get_attribute(key) else allocation.quantity * UNIT_TO_QUOTA_MAPPING[key]

--- a/src/coldfront_plugin_openstack/tasks.py
+++ b/src/coldfront_plugin_openstack/tasks.py
@@ -111,6 +111,10 @@ def activate_allocation(allocation_pk):
     # Does it have to do with linked resources?
     resource = allocation.resources.first()
     if is_openstack_resource(resource):
+        if allocation.quantity < 1:
+            # This could lead to negative values which can be interpreted as no quota
+            allocation.quantity = 1
+
         ksa_session = get_session_for_resource(resource)
         identity = client.Client(session=ksa_session)
 

--- a/src/coldfront_plugin_openstack/tests/base.py
+++ b/src/coldfront_plugin_openstack/tests/base.py
@@ -1,3 +1,5 @@
+from os import devnull
+import sys
 import uuid
 
 from django.test import TestCase
@@ -24,9 +26,12 @@ from coldfront_plugin_openstack import attributes
 class TestBase(TestCase):
 
     def setUp(self) -> None:
-        call_command('initial_setup')
+        # Otherwise output goes to the terminal for every test that is run
+        backup, sys.stdout = sys.stdout, open(devnull, 'a')
+        call_command('initial_setup', )
         call_command('load_test_data')
         call_command('register_openstack_attributes')
+        sys.stdout = backup
 
     @staticmethod
     def new_user(username=None) -> User:

--- a/src/coldfront_plugin_openstack/tests/base.py
+++ b/src/coldfront_plugin_openstack/tests/base.py
@@ -1,0 +1,138 @@
+import uuid
+
+from django.test import TestCase
+
+from coldfront.core.allocation.models import (Allocation,
+                                              AllocationStatusChoice,
+                                              AllocationUser,
+                                              AllocationUserStatusChoice)
+
+from django.contrib.auth.models import User
+from coldfront.core.project.models import (Project,
+                                           ProjectUser,
+                                           ProjectUserRoleChoice,
+                                           ProjectUserStatusChoice, ProjectStatusChoice)
+from coldfront.core.resource.models import (Resource,
+                                            ResourceType,
+                                            ResourceAttribute,
+                                            ResourceAttributeType)
+from django.core.management import call_command
+
+from coldfront_plugin_openstack import attributes
+
+
+class TestBase(TestCase):
+
+    def setUp(self) -> None:
+        call_command('initial_setup')
+        call_command('load_test_data')
+        call_command('register_openstack_attributes')
+
+    @staticmethod
+    def new_user(username=None) -> User:
+        username = username or f'{uuid.uuid4().hex}@example.com'
+        User.objects.create(username=username, email=username)
+        return User.objects.get(username=username)
+
+    @staticmethod
+    def new_resource(name=None, auth_url=None) -> Resource:
+        # TODO: User call_command on add_openstack_resource instead of duplicating this
+        resource_name = name or uuid.uuid4().hex
+
+        Resource.objects.create(
+            resource_type=ResourceType.objects.get(name='OpenStack'),
+            parent_resource=None,
+            name=resource_name,
+            description='OpenStack test cloud environment',
+            is_available=True,
+            is_public=True,
+            is_allocatable=True
+        )
+        openstack = Resource.objects.get(name=resource_name)
+
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name=attributes.RESOURCE_AUTH_URL),
+            resource=openstack,
+            value=auth_url or f'https://{resource_name}/identity/v3'
+        )
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name=attributes.RESOURCE_PROJECT_DOMAIN),
+            resource=openstack,
+            value='default'
+        )
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name=attributes.RESOURCE_USER_DOMAIN),
+            resource=openstack,
+            value='default'
+        )
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name=attributes.RESOURCE_IDP),
+            resource=openstack,
+            value='sso'
+        )
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name=attributes.RESOURCE_FEDERATION_PROTOCOL),
+            resource=openstack,
+            value='openid'
+        )
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name=attributes.RESOURCE_ROLE),
+            resource=openstack,
+            value='member'
+        )
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name='quantity_label'),
+            resource=openstack,
+            value='Units of computing to allocate to the project. 1 Unit = 1 Instance, 2 vCPU, 4G RAM'
+        )
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name='quantity_default_value'),
+            resource=openstack,
+            value=1
+        )
+
+        return openstack
+
+    def new_project(self, title=None, pi=None) -> Project:
+        title = title or uuid.uuid4().hex
+        pi = pi or self.new_user()
+        status = ProjectStatusChoice.objects.get(name='New')
+
+        Project.objects.create(title=title, pi=pi, status=status)
+        return Project.objects.get(title=title)
+
+    def new_project_user(self, user, project, role='Manager', status='Active'):
+        pu, _ = ProjectUser.objects.get_or_create(
+            user=user,
+            project=project,
+            role=ProjectUserRoleChoice.objects.get(name=role),
+            status=ProjectUserStatusChoice.objects.get(name=status)
+        )
+        return pu
+
+    def new_allocation(self, project, resource, quantity):
+        allocation, _ = Allocation.objects.get_or_create(
+            project=project,
+            justification='a justification for testing data',
+            quantity=quantity,
+            status=AllocationStatusChoice.objects.get(
+                name='New')
+        )
+        allocation.resources.add(resource)
+        return allocation
+
+    def new_allocation_user(self, allocation, user):
+        au, _ = AllocationUser.objects.get_or_create(
+            allocation=allocation,
+            user=user,
+            status=AllocationUserStatusChoice.objects.get(name='Active')
+        )
+        return au

--- a/src/coldfront_plugin_openstack/tests/functional/test_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/functional/test_allocation.py
@@ -1,0 +1,85 @@
+import os
+import unittest
+from unittest import mock
+
+from coldfront.core.allocation.models import Allocation
+from coldfront.core.resource.models import Resource
+
+from coldfront_plugin_openstack import attributes
+from coldfront_plugin_openstack import tasks
+from coldfront_plugin_openstack.tests import base
+
+from keystoneauth1.identity import v3
+from keystoneauth1 import session
+from keystoneclient.v3 import client
+from cinderclient import client as cinderclient
+from neutronclient.v2_0 import client as neutronclient
+from novaclient import client as novaclient
+
+
+@unittest.skipUnless(os.getenv('FUNCTIONAL_TESTS'), 'Functional tests not enabled.')
+class TestAllocation(base.TestBase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource = self.new_resource(name='Devstack',
+                                          auth_url='http://localhost:5000')
+        self.session = tasks.get_session_for_resource(self.resource)
+        self.identity = client.Client(session=self.session)
+        self.compute = novaclient.Client(tasks.NOVA_VERSION,
+                                         session=self.session)
+
+    def test_new_allocation(self):
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 1)
+
+        tasks.activate_allocation(allocation.pk)
+        allocation.refresh_from_db()
+
+        project_id = allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+        self.assertIsNotNone(project_id)
+        self.assertIsNotNone(allocation.get_attribute(attributes.ALLOCATION_PROJECT_NAME))
+
+        openstack_project = self.identity.projects.get(project_id)
+        self.assertTrue(openstack_project.enabled)
+
+        # TODO: Assert correct quota
+
+    def test_reactivate_allocation(self):
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 1)
+
+        tasks.activate_allocation(allocation.pk)
+
+        project_id = allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+        openstack_project = self.identity.projects.get(project_id)
+        openstack_project.update(enabled=False)
+
+        tasks.activate_allocation(allocation.pk)  # noqa
+        allocation.refresh_from_db()
+
+        project_id = allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+        openstack_project = self.identity.projects.get(project_id)
+        self.assertTrue(openstack_project.enabled)
+
+        # TODO: assert quotas match expected quotas
+
+    def test_add_user(self):
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        project_user = self.new_project_user(user, project)
+        allocation = self.new_allocation(project, self.resource, 1)
+        allocation_user = self.new_allocation_user(allocation, user)
+
+        tasks.activate_allocation(allocation.pk)
+        allocation.refresh_from_db()
+
+        project_id = allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+        openstack_project = self.identity.projects.get(project_id)
+
+        tasks.add_user_to_allocation(allocation_user.pk)
+
+        # TODO: check user created in openstack
+        # TODO: check user has roles assignmed in openstack

--- a/src/coldfront_plugin_openstack/tests/test_resource_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/test_resource_allocation.py
@@ -1,5 +1,0 @@
-from django.test import TestCase
-
-
-class TestResourceAllocation(TestCase):
-    pass

--- a/src/coldfront_plugin_openstack/tests/test_resource_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/test_resource_allocation.py
@@ -1,0 +1,5 @@
+from django.test import TestCase
+
+
+class TestResourceAllocation(TestCase):
+    pass

--- a/src/local_settings.py
+++ b/src/local_settings.py
@@ -1,0 +1,8 @@
+import pkgutil
+
+from coldfront.config.settings import *
+from django.conf import settings
+
+plugin_openstack = pkgutil.get_loader('coldfront_plugin_openstack.config')
+
+include(plugin_openstack.get_filename())


### PR DESCRIPTION
- [x] Sets up and configures Microstack using GitHub actions
- [x] Creates the base class for unit tests and helper functions to set up ColdFront models such as resources, allocations, users, etc.
- [x] Refactors the code base to eliminate some of the code duplication. Adds a setup.py and local_settings.py for dev environments.
- [x] End to end tests of creating a resource allocation and setting quotas
- [x] Partially implements quotas for nova and cinder

Reviewing is easier when going commit by commit, as most of them are pretty self-contained. When going down like that, there are some bugs however, which were introduced during refactoring and only caught by the [commit that introduces  testing](https://github.com/nerc-project/coldfront-plugin-openstack/commit/72516cd8e27dbc8e9a93c4b496819404398a404f).

Closes #2
Partial #1