### PR TITLE
Add PI on allocation activation and fix CI

### DIFF
--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,5 +1,6 @@
 # Installs and starts Microstack on a Ubuntu system
 # Only run once.
+set -xe
 
 openstack_cmd="microstack.openstack"
 
@@ -17,5 +18,5 @@ sudo apt-get install -y python3-pip python3-virtualenv python3.9
 virtualenv -p python3.9 /tmp/coldfront_venv
 source /tmp/coldfront_venv/bin/activate
 
-pip3 install -r requirements.txt
+pip3 install -r test-requirements.txt
 pip3 install -e .


### PR DESCRIPTION
- PI was not being added on activation allocation. This change
  fixes that with some small refactoring of the create user and
  role assignment methods. Augmented tests for this case.
- CI was broken since Microstack moved to requiring self-signed
  HTTPS. This fixes that by adding a check to the
  FUNCTIONAL_TESTS='True' environment variable.

Closes #6 
Closes #10