### PR TITLE
Use Django-Q async_task for allocation activation

### DIFF
--- a/src/coldfront_plugin_openstack/signals.py
+++ b/src/coldfront_plugin_openstack/signals.py
@@ -1,4 +1,5 @@
 from django.dispatch import receiver
+from django_q.tasks import async_task
 
 from coldfront_plugin_openstack.tasks import (activate_allocation,
                                               add_user_to_allocation,
@@ -13,26 +14,22 @@ from coldfront.core.allocation.signals import (allocation_activate,
 @receiver(allocation_activate)
 def activate_allocation_receiver(sender, **kwargs):
     allocation_pk = kwargs.get('allocation_pk')
-    # TODO: Async implementation
-    activate_allocation(allocation_pk)
+    async_task(activate_allocation, allocation_pk)
 
 
 @receiver(allocation_disable)
 def allocation_disable_receiver(sender, **kwargs):
     allocation_pk = kwargs.get('allocation_pk')
-    # TODO: Async implementation
     disable_allocation(allocation_pk)
 
 
 @receiver(allocation_activate_user)
 def activate_allocation_user_receiver(sender, **kwargs):
     allocation_user_pk = kwargs.get('allocation_user_pk')
-    # TODO: Async implementation
     add_user_to_allocation(allocation_user_pk)
 
 
 @receiver(allocation_remove_user)
 def allocation_remove_user_receiver(sender, **kwargs):
     allocation_user_pk = kwargs.get('allocation_user_pk')
-    # TODO: Async implementation
     remove_user_from_allocation(allocation_user_pk)


### PR DESCRIPTION
Requires the appropriate configuration for a Django-Q cluster
and Redis database as described in Django-Q documentation.