### PR TITLE
Url encode unique_id in create_user call

### DIFF
--- a/.github/workflows/test-py39-functional.yaml
+++ b/.github/workflows/test-py39-functional.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install and start Microstack
         run: |
-          sudo snap install microstack --beta --devmode
+          sudo snap install microstack --edge --devmode
           sudo microstack init --auto --control
           microstack.openstack domain create sso
           microstack.openstack identity provider create sso --domain sso

--- a/src/coldfront_plugin_openstack/signals.py
+++ b/src/coldfront_plugin_openstack/signals.py
@@ -1,3 +1,5 @@
+import os
+
 from django.dispatch import receiver
 from django_q.tasks import async_task
 
@@ -14,7 +16,12 @@ from coldfront.core.allocation.signals import (allocation_activate,
 @receiver(allocation_activate)
 def activate_allocation_receiver(sender, **kwargs):
     allocation_pk = kwargs.get('allocation_pk')
-    async_task(activate_allocation, allocation_pk)
+    # Note(knikolla): Only run this task using Django-Q if a qcluster has
+    # been configured.
+    if os.getenv('REDIS_HOST'):
+        async_task(activate_allocation, allocation_pk)
+    else:
+        activate_allocation(allocation_pk)
 
 
 @receiver(allocation_disable)

--- a/src/coldfront_plugin_openstack/tasks.py
+++ b/src/coldfront_plugin_openstack/tasks.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import urllib.parse
 
 from coldfront.core.allocation.models import (Allocation,
                                               AllocationUser)
@@ -77,13 +78,14 @@ def get_user_payload_for_resource(resource, username):
             'domain_id': domain_id,
             'enabled': True,
             'name': username,
+            'email': username,
             'federated': [
                 {
                     'idp_id': idp_id,
                     'protocols': [
                         {
                             'protocol_id': protocol,
-                            'unique_id': username
+                            'unique_id': urllib.parse.quote_plus(username)
                         }
                     ]
                 }

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ubccr/coldfront@7bc52c05ba1246b50c5fd5877d8e9184045042ab#egg=coldfront
+git+https://github.com/ubccr/coldfront@7dc4391c0cb54ec85ff82a0199ff0461454d5fb0#egg=coldfront
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient
 python-memcached==1.59


### PR DESCRIPTION
- The unique_id parsed by keystone for federated users logging in
  to the NERC is url encoded (based on what I observed testing).
  Therefore the create users call should url encode the unique
  id as well.
- Updated the coldfront has in test-requirements to match latest
  Coldfront master.
- Added a conditional to async_task so that the task isn't attempting
  to run asynchronously unless Django-Q is configured.