### PR TITLE
[WIP] Impersonate user login via Keycloak

### DIFF
--- a/ci/run_functional_tests.sh
+++ b/ci/run_functional_tests.sh
@@ -21,6 +21,9 @@ export KEYCLOAK_URL="http://$HOST_IP:8080"
 export KEYCLOAK_USER="admin"
 export KEYCLOAK_PASS="nomoresecret"
 export KEYCLOAK_REALM="master"
+export OIDC_RP_CLIENT_ID="devstack"
+export OIDC_RP_CLIENT_SECRET="nomoresecret"
+export OIDC_REDIRECT_URI="http://$HOST_IP/identity/v3/auth/OS-FEDERATION/identity_providers/sso/protocols/openid/websso"
 
 coldfront test coldfront_plugin_openstack.tests.functional
 

--- a/src/coldfront_plugin_openstack/attributes.py
+++ b/src/coldfront_plugin_openstack/attributes.py
@@ -5,12 +5,16 @@ RESOURCE_PROJECT_DOMAIN = 'OpenStack Domain for Projects'
 RESOURCE_ROLE = 'OpenStack Role for User in Project'
 RESOURCE_USER_DOMAIN = 'OpenStack Domain for Users'
 
-RESOURCE_ATTRIBUTES = [RESOURCE_AUTH_URL,
-                       RESOURCE_FEDERATION_PROTOCOL,
-                       RESOURCE_IDP,
-                       RESOURCE_PROJECT_DOMAIN,
-                       RESOURCE_ROLE,
-                       RESOURCE_USER_DOMAIN]
+RESOURCE_SUPPORTS_FED_ATTR = 'OpenStack Identity supports federated create'
+
+RESOURCE_ATTRIBUTES_TEXT = [RESOURCE_AUTH_URL,
+                            RESOURCE_FEDERATION_PROTOCOL,
+                            RESOURCE_IDP,
+                            RESOURCE_PROJECT_DOMAIN,
+                            RESOURCE_ROLE,
+                            RESOURCE_USER_DOMAIN]
+RESOURCE_ATTRIBUTES_BOOL = [RESOURCE_SUPPORTS_FED_ATTR]
+
 
 ALLOCATION_PROJECT_ID = 'OpenStack Project ID'
 ALLOCATION_PROJECT_NAME = 'OpenStack Project Name'

--- a/src/coldfront_plugin_openstack/keycloak.py
+++ b/src/coldfront_plugin_openstack/keycloak.py
@@ -1,0 +1,51 @@
+import logging
+import os
+import urllib.parse
+import requests
+
+from coldfront_plugin_keycloak_usersearch import keycloak as kc
+
+
+logger = logging.getLogger(__name__)
+
+
+class KeycloakClient(kc.KeycloakClient):
+
+    def create_user(self, realm, username, email, first_name, last_name):
+        self._admin_auth()
+        data = {
+            'username': username,
+            'email': email,
+            'firstName': first_name,
+            'lastName': last_name,
+            'enabled': True,
+            'emailVerified': True,
+            'requiredActions': []
+        }
+        r = self.session.post(self.construct_url(realm, 'users'), json=data)
+        logger.info(f'Created user {r.text}')
+        return r
+
+    def impersonate(self, user, realm):
+        self._admin_auth()
+        user = self.search_username(user, realm)[0]["id"]
+        logger.info(f'Impersonating user ID {user}')
+        r = self.session.post(self.construct_url(realm, f'users/{user}/impersonation'))
+        return r
+
+    def impersonate_access_token(self, user, realm, client_id, client_secret):
+        user_session = requests.session()
+        user_session.cookies.update(self.impersonate(user, realm).cookies)
+        params = {
+            'response_mode': 'fragment',
+            'response_type': 'token',
+            'client_id': client_id,
+            'client_secret': client_secret,
+            # 'redirect_uri': f'{self.url}/realms/{realm}/account/',
+            'redirect_uri': os.getenv('OIDC_REDIRECT_URI')
+        }
+        response = user_session.get(self.auth_endpoint(realm), params=params, allow_redirects=False)
+        redirect = response.headers['Location']
+        token = urllib.parse.parse_qs(redirect)['access_token'][0]
+        logger.warning(f'access token {token}')
+        return token

--- a/src/coldfront_plugin_openstack/management/commands/register_openstack_attributes.py
+++ b/src/coldfront_plugin_openstack/management/commands/register_openstack_attributes.py
@@ -26,12 +26,18 @@ class Command(BaseCommand):
             register(allocation_quota_attribute, 'Int')
 
     def register_resource_attributes(self):
-        for resource_attribute_type in attributes.RESOURCE_ATTRIBUTES:
-            resource_models.ResourceAttributeType.objects.get_or_create(
-                name=resource_attribute_type,
-                attribute_type=resource_models.AttributeType.objects.get(
-                    name='Text')
-            )
+        type_list_mapping = {
+            'Text': attributes.RESOURCE_ATTRIBUTES_TEXT,
+            'Yes/No': attributes.RESOURCE_ATTRIBUTES_BOOL
+        }
+
+        for attribute_type, attribute_list in type_list_mapping.items():
+            for resource_attribute in attribute_list:
+                resource_models.ResourceAttributeType.objects.get_or_create(
+                    name=resource_attribute,
+                    attribute_type=resource_models.AttributeType.objects.get(
+                        name=attribute_type)
+                )
 
     def register_resource_type(self):
         resource_models.ResourceType.objects.get_or_create(

--- a/src/coldfront_plugin_openstack/tests/base.py
+++ b/src/coldfront_plugin_openstack/tests/base.py
@@ -40,7 +40,7 @@ class TestBase(TestCase):
         return User.objects.get(username=username)
 
     @staticmethod
-    def new_resource(name=None, auth_url=None) -> Resource:
+    def new_resource(name=None, auth_url=None, supports_fed_attr=None) -> Resource:
         # TODO: User call_command on add_openstack_resource instead of duplicating this
         resource_name = name or uuid.uuid4().hex
 
@@ -103,6 +103,14 @@ class TestBase(TestCase):
             resource=openstack,
             value=1
         )
+
+        if supports_fed_attr:
+            ResourceAttribute.objects.get_or_create(
+                resource_attribute_type=ResourceAttributeType.objects.get(
+                    name=attributes.RESOURCE_SUPPORTS_FED_ATTR),
+                resource=openstack,
+                value=supports_fed_attr
+            )
 
         return openstack
 

--- a/src/coldfront_plugin_openstack/tests/functional/test_users.py
+++ b/src/coldfront_plugin_openstack/tests/functional/test_users.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+import uuid
+
+from coldfront_plugin_openstack import attributes
+from coldfront_plugin_openstack import tasks
+from coldfront_plugin_openstack.tests import base
+from coldfront_plugin_openstack import keycloak
+
+from keystoneauth1.identity import v3
+from keystoneauth1 import session
+from keystoneclient.v3 import client
+from cinderclient import client as cinderclient
+from neutronclient.v2_0 import client as neutronclient
+from novaclient import client as novaclient
+
+
+@unittest.skipUnless(os.getenv('KEYCLOAK_URL'), 'Keycloak not configured.')
+@unittest.skipUnless(os.getenv('FUNCTIONAL_TESTS'), 'Functional tests not enabled.')
+class TestImpersonate(base.TestBase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource = self.new_resource(name='Devstack',
+                                          auth_url=os.getenv('OS_AUTH_URL'),
+                                          supports_fed_attr='No')
+        self.session = tasks.get_session_for_resource(self.resource)
+        self.identity = client.Client(session=self.session)
+        self.keycloak = keycloak.KeycloakClient(os.getenv('KEYCLOAK_URL'),
+                                                os.getenv('KEYCLOAK_USER'),
+                                                os.getenv('KEYCLOAK_PASS'))
+
+    def test_impersonate_user_login(self):
+        username = uuid.uuid4().hex
+        self.keycloak.create_user('master', username, username, username, username)
+        user = tasks.get_or_create_federated_user(self.resource, username)
+        self.assertEqual(username, user['name'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/ubccr/coldfront@7dc4391c0cb54ec85ff82a0199ff0461454d5fb0#egg=coldfront
+git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient
 python-memcached==1.59


### PR DESCRIPTION
- [x] Add resource attribute `OpenStack Identity supports federated create` of type `Yes/No` to flag whether the federated attributes on the users API should be used to create a user or impersonation.
- [x] Added `coldfront-plugin-keycloak` to requirements.
- [x] Added logging if plugin is unavailable or not configured and therefore unable to create users.
- [x] Implemented admin log in via username and password.
- [ ] Update `coldfront-plugin-keycloak` to use client credentials login instead of username and password.
- [ ] Pull ^ here.