### PR TITLE
Add Devstack job to CI with OIDC

### DIFF
--- a/.github/workflows/test-py38-functional-devstack.yaml
+++ b/.github/workflows/test-py38-functional-devstack.yaml
@@ -1,0 +1,26 @@
+name: test-py38-functional-devstack
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Devstack and Keycloak
+        run: |
+          ./ci/devstack.sh
+
+      - name: Install ColdFront and plugin
+        run: |
+          ./ci/setup.sh
+
+      - name: Run functional tests
+        run: |
+          ./ci/run_functional_tests.sh

--- a/.github/workflows/test-py39-functional.yaml
+++ b/.github/workflows/test-py39-functional.yaml
@@ -42,5 +42,6 @@ jobs:
               microstack.openstack application credential create "$CREDENTIAL_NAME" -f value -c secret)
           export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID=$(
               microstack.openstack application credential show "$CREDENTIAL_NAME" -f value -c id)
+          export OS_AUTH_URL="https://localhost:5000"
 
           coldfront test coldfront_plugin_openstack.tests.functional

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,21 @@
+Vagrant.configure("2") do |config|
+    config.vm.box = "generic/ubuntu2004"
+    config.vm.synced_folder ".", "/home/vagrant/coldfront-plugin-openstack/"
+
+    config.vm.network :private_network
+
+    config.vm.provider "vmware_fusion" do |vb|
+        vb.gui = false
+        vb.memory = "9000"
+        vb.cpus = "4"
+    end
+
+    config.vm.provision "shell", privileged: false, inline: <<-SHELL
+        set -xe
+
+        cd ~/coldfront-plugin-openstack
+        ./ci/devstack.sh
+        ./ci/setup.sh
+        ./ci/run_functional_tests.sh
+    SHELL
+end

--- a/ci/devstack.sh
+++ b/ci/devstack.sh
@@ -1,0 +1,42 @@
+#
+# Installs Devstack with the OIDC plugin
+#
+set -xe
+
+sudo apt-get update && sudo apt-get upgrade -y
+
+sudo mkdir -p /opt/stack
+sudo chown "$USER:$USER" /opt/stack
+
+git clone https://github.com/knikolla/devstack-plugin-oidc /opt/stack/devstack-plugin-oidc
+source /opt/stack/devstack-plugin-oidc/tools/config.sh
+
+# Start Keycloak
+cd /opt/stack/devstack-plugin-oidc/tools && sudo docker-compose up -d
+
+# Install and start Devstack
+git clone https://opendev.org/openstack/devstack.git /opt/stack/devstack
+cd /opt/stack/devstack
+
+cp samples/local.conf .
+
+# Github Actions sets the CI environment variable
+if [[ "${CI}" == "true" ]]; then
+    sudo systemctl start mysql
+
+    echo "
+        disable_service horizon
+        disable_service tempest
+        INSTALL_DATABASE_SERVER_PACKAGES=False
+        DATABASE_PASSWORD=root
+    " >> local.conf
+fi
+
+echo "
+    IP_VERSION=4
+    KEYSTONE_ADMIN_ENDPOINT=True
+    enable_plugin devstack-plugin-oidc https://github.com/knikolla/devstack-plugin-oidc main
+" >> local.conf
+./stack.sh
+
+python3 /opt/stack/devstack-plugin-oidc/tools/test_login.py

--- a/ci/run_functional_tests.sh
+++ b/ci/run_functional_tests.sh
@@ -1,19 +1,27 @@
 # Creates the appropriate credentials and runs tests
 #
 # Tests expect the resource to be name Devstack
-openstack_cmd="microstack.openstack"
+
+source /opt/stack/devstack-plugin-oidc/tools/config.sh
+source /opt/stack/devstack/openrc admin admin
+
 credential_name=$(openssl rand -base64 12)
 
 export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_SECRET=$(
-    $openstack_cmd application credential create "$credential_name" -f value -c secret)
+    openstack application credential create "$credential_name" -f value -c secret)
 export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID=$(
-    $openstack_cmd application credential show "$credential_name" -f value -c id)
+    openstack application credential show "$credential_name" -f value -c id)
 
 source /tmp/coldfront_venv/bin/activate
 
 export DJANGO_SETTINGS_MODULE="local_settings"
 export FUNCTIONAL_TESTS="True"
+export OS_AUTH_URL="http://$HOST_IP/identity"
+export KEYCLOAK_URL="http://$HOST_IP:8080"
+export KEYCLOAK_USER="admin"
+export KEYCLOAK_PASS="nomoresecret"
+export KEYCLOAK_REALM="master"
 
 coldfront test coldfront_plugin_openstack.tests.functional
 
-microstack.openstack application credential delete $OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID
+openstack application credential delete $OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,21 +1,6 @@
-# Installs and starts Microstack on a Ubuntu system
-# Only run once.
 set -xe
 
-openstack_cmd="microstack.openstack"
-
-sudo snap install microstack --beta --devmode
-sudo microstack init --auto --control
-
-$openstack_cmd domain create sso
-$openstack_cmd identity provider create sso --domain sso
-$openstack_cmd mapping create sso_mapping --rules ci/mapping.json
-$openstack_cmd federation protocol create openid --identity-provider sso --mapping sso_mapping
-
-sudo apt-get update
-sudo apt-get install -y python3-pip python3-virtualenv python3.9
-
-virtualenv -p python3.9 /tmp/coldfront_venv
+virtualenv -p python3 /tmp/coldfront_venv
 source /tmp/coldfront_venv/bin/activate
 
 pip3 install -r test-requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.8
 install_requires =
     coldfront >= 1.0.4
     python-cinderclient


### PR DESCRIPTION
- Install Devstack with the OpenID Connect plugin from
  https://github.com/knikolla/devstack-plugin-oidc
- Lower python requirement to 3.8