### PR TITLE
Support allocation changes and networking quota

### DIFF
--- a/ci/devstack.sh
+++ b/ci/devstack.sh
@@ -8,6 +8,10 @@ sudo apt-get update && sudo apt-get upgrade -y
 sudo mkdir -p /opt/stack
 sudo chown "$USER:$USER" /opt/stack
 
+if [[ ! "${CI}" == "true" ]]; then
+    sudo apt-get install docker.io docker-compose -y
+fi
+
 git clone https://github.com/knikolla/devstack-plugin-oidc /opt/stack/devstack-plugin-oidc
 source /opt/stack/devstack-plugin-oidc/tools/config.sh
 

--- a/ci/run_functional_tests.sh
+++ b/ci/run_functional_tests.sh
@@ -1,6 +1,7 @@
 # Creates the appropriate credentials and runs tests
 #
 # Tests expect the resource to be name Devstack
+set -xe
 
 source /opt/stack/devstack-plugin-oidc/tools/config.sh
 source /opt/stack/devstack/openrc admin admin

--- a/src/coldfront_plugin_openstack/attributes.py
+++ b/src/coldfront_plugin_openstack/attributes.py
@@ -29,9 +29,12 @@ QUOTA_VCPU = 'OpenStack Compute vCPU Quota'
 QUOTA_VOLUMES = 'OpenStack Volume Quota'
 QUOTA_VOLUMES_GB = 'OpenStack Volume GB Quota'
 
+QUOTA_FLOATING_IPS = 'OpenStack Floating IP Quota'
+
 ALLOCATION_QUOTA_ATTRIBUTES = [QUOTA_INSTANCES,
                                QUOTA_RAM,
                                QUOTA_VCPU,
                                QUOTA_VOLUMES,
-                               QUOTA_VOLUMES_GB]
+                               QUOTA_VOLUMES_GB,
+                               QUOTA_FLOATING_IPS,]
 

--- a/src/coldfront_plugin_openstack/management/commands/register_openstack_attributes.py
+++ b/src/coldfront_plugin_openstack/management/commands/register_openstack_attributes.py
@@ -16,7 +16,8 @@ class Command(BaseCommand):
                 attribute_type=allocation_models.AttributeType.objects.get(
                     name=attribute_type),
                 has_usage=False,
-                is_private=False
+                is_private=False,
+                is_changeable='Quota' in attribute_name
             )
 
         for allocation_attribute in attributes.ALLOCATION_ATTRIBUTES:

--- a/src/coldfront_plugin_openstack/signals.py
+++ b/src/coldfront_plugin_openstack/signals.py
@@ -10,10 +10,12 @@ from coldfront_plugin_openstack.tasks import (activate_allocation,
 from coldfront.core.allocation.signals import (allocation_activate,
                                                allocation_activate_user,
                                                allocation_disable,
-                                               allocation_remove_user)
+                                               allocation_remove_user,
+                                               allocation_change_approved)
 
 
 @receiver(allocation_activate)
+@receiver(allocation_change_approved)
 def activate_allocation_receiver(sender, **kwargs):
     allocation_pk = kwargs.get('allocation_pk')
     # Note(knikolla): Only run this task using Django-Q if a qcluster has

--- a/src/coldfront_plugin_openstack/tests/functional/test_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/functional/test_allocation.py
@@ -22,9 +22,9 @@ class TestAllocation(base.TestBase):
                                           auth_url=os.getenv('OS_AUTH_URL'))
         self.session = tasks.get_session_for_resource(self.resource)
         self.identity = client.Client(session=self.session)
-        self.compute = novaclient.Client(tasks.NOVA_VERSION,
+        self.compute = novaclient.Client(tasks.QUOTA_KEY_MAPPING['compute']['version'],
                                          session=self.session)
-        self.volume = cinderclient.Client(tasks.CINDER_VERSION,
+        self.volume = cinderclient.Client(tasks.QUOTA_KEY_MAPPING['volume']['version'],
                                           session=self.session)
         self.networking = neutronclient.Client(session=self.session)
         self.role_member = self.identity.roles.find(name='member')
@@ -67,9 +67,12 @@ class TestAllocation(base.TestBase):
         self.assertEqual(ports[0]['status'], 'ACTIVE')
 
         # Check quota
-        union_key_mappings = dict(tasks.NOVA_KEY_MAPPING, **tasks.CINDER_KEY_MAPPING)
+        union_key_mappings = dict(tasks.QUOTA_KEY_MAPPING['compute']['keys'],
+                                  **tasks.QUOTA_KEY_MAPPING['volume']['keys'])
+        unit_to_quota_union = dict(tasks.UNIT_TO_QUOTA_MAPPING['compute'],
+                                   **tasks.UNIT_TO_QUOTA_MAPPING['volume'])
         expected_quotas = {
-            union_key_mappings[x]: tasks.UNIT_TO_QUOTA_MAPPING[x]
+            union_key_mappings[x]: unit_to_quota_union[x]
             for x in attributes.ALLOCATION_QUOTA_ATTRIBUTES
         }
         actual_quotas = dict(
@@ -105,9 +108,12 @@ class TestAllocation(base.TestBase):
         self.assertEqual(roles[0].role['id'], self.role_member.id)
 
         # Check quota
-        union_key_mappings = dict(tasks.NOVA_KEY_MAPPING, **tasks.CINDER_KEY_MAPPING)
+        union_key_mappings = dict(tasks.QUOTA_KEY_MAPPING['compute']['keys'],
+                                  **tasks.QUOTA_KEY_MAPPING['volume']['keys'])
+        unit_to_quota_union = dict(tasks.UNIT_TO_QUOTA_MAPPING['compute'],
+                                   **tasks.UNIT_TO_QUOTA_MAPPING['volume'])
         expected_quotas = {
-            union_key_mappings[x]: tasks.UNIT_TO_QUOTA_MAPPING[x] * 3
+            union_key_mappings[x]: unit_to_quota_union[x]
             for x in attributes.ALLOCATION_QUOTA_ATTRIBUTES
         }
         actual_quotas = dict(

--- a/src/coldfront_plugin_openstack/tests/functional/test_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/functional/test_allocation.py
@@ -1,8 +1,7 @@
 import os
 import unittest
 
-from coldfront_plugin_openstack import attributes
-from coldfront_plugin_openstack import tasks
+from coldfront_plugin_openstack import attributes, tasks, utils
 from coldfront_plugin_openstack.tests import base
 
 from keystoneauth1.identity import v3
@@ -66,20 +65,36 @@ class TestAllocation(base.TestBase):
         self.assertIsNotNone(ports)
         self.assertEqual(ports[0]['status'], 'ACTIVE')
 
-        # Check quota
-        union_key_mappings = dict(tasks.QUOTA_KEY_MAPPING['compute']['keys'],
-                                  **tasks.QUOTA_KEY_MAPPING['volume']['keys'])
-        unit_to_quota_union = dict(tasks.UNIT_TO_QUOTA_MAPPING['compute'],
-                                   **tasks.UNIT_TO_QUOTA_MAPPING['volume'])
-        expected_quotas = {
-            union_key_mappings[x]: unit_to_quota_union[x]
-            for x in attributes.ALLOCATION_QUOTA_ATTRIBUTES
+        # Check nova quota
+        expected_nova_quota = {
+            'instances': 1,
+            'cores': 2,
+            'ram': 4096,
         }
-        actual_quotas = dict(
-            self.compute.quotas.get(openstack_project.id).to_dict(),
-            **self.volume.quotas.get(openstack_project.id).to_dict()
-        )
-        self.assertEqual(actual_quotas, dict(expected_quotas, **actual_quotas))
+        actual_nova_quota = self.compute.quotas.get(openstack_project.id)
+        for k, v in expected_nova_quota.items():
+            self.assertEqual(actual_nova_quota.__getattr__(k), v)
+
+        # Check cinder quota
+        expected_cinder_quota = {
+            'volumes': 2,
+            'gigabytes': 100,
+        }
+        actual_cinder_quota = self.volume.quotas.get(openstack_project.id)
+        for k, v in expected_cinder_quota.items():
+            self.assertEqual(actual_cinder_quota.__getattr__(k), v)
+
+        # Check neutron quota
+        expected_neutron_quota = {
+            'floatingip': 2,
+        }
+        actual_neutron_quota = self.networking.show_quota(openstack_project.id)['quota']
+        for k, v in expected_neutron_quota.items():
+            self.assertEqual(actual_neutron_quota.get(k), v)
+
+        # Check correct attributes
+        for attr in attributes.ALLOCATION_QUOTA_ATTRIBUTES:
+            self.assertIsNotNone(allocation.get_attribute(attr))
 
     def test_new_allocation_with_quantity(self):
         user = self.new_user()
@@ -108,19 +123,48 @@ class TestAllocation(base.TestBase):
         self.assertEqual(roles[0].role['id'], self.role_member.id)
 
         # Check quota
-        union_key_mappings = dict(tasks.QUOTA_KEY_MAPPING['compute']['keys'],
-                                  **tasks.QUOTA_KEY_MAPPING['volume']['keys'])
-        unit_to_quota_union = dict(tasks.UNIT_TO_QUOTA_MAPPING['compute'],
-                                   **tasks.UNIT_TO_QUOTA_MAPPING['volume'])
-        expected_quotas = {
-            union_key_mappings[x]: unit_to_quota_union[x]
-            for x in attributes.ALLOCATION_QUOTA_ATTRIBUTES
+        # Check nova quota
+        expected_nova_quota = {
+            'instances': 1 * 3,
+            'cores': 2 * 3,
+            'ram': 4096 * 3,
         }
-        actual_quotas = dict(
-            self.compute.quotas.get(openstack_project.id).to_dict(),
-            **self.volume.quotas.get(openstack_project.id).to_dict()
-        )
-        self.assertEqual(actual_quotas, dict(expected_quotas, **actual_quotas))
+        actual_nova_quota = self.compute.quotas.get(openstack_project.id)
+        for k, v in expected_nova_quota.items():
+            self.assertEqual(actual_nova_quota.__getattr__(k), v)
+
+        # Check cinder quota
+        expected_cinder_quota = {
+            'volumes': 2 * 3,
+            'gigabytes': 100 * 3,
+        }
+        actual_cinder_quota = self.volume.quotas.get(openstack_project.id)
+        for k, v in expected_cinder_quota.items():
+            self.assertEqual(actual_cinder_quota.__getattr__(k), v)
+
+        # Check neutron quota
+        expected_neutron_quota = {
+            'floatingip': 2,
+        }
+        actual_neutron_quota = self.networking.show_quota(openstack_project.id)['quota']
+        for k, v in expected_neutron_quota.items():
+            self.assertEqual(actual_neutron_quota.get(k), v)
+
+        # Change allocation attribute for floating ips and cores
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_FLOATING_IPS), 2)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_VCPU), 2 * 3)
+        utils.set_attribute_on_allocation(allocation, attributes.QUOTA_FLOATING_IPS, 3)
+        utils.set_attribute_on_allocation(allocation, attributes.QUOTA_VCPU, 100)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_FLOATING_IPS), 3)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_VCPU), 100)
+
+        tasks.activate_allocation(allocation.pk)
+
+        # Recheck neutron quota after attribute change
+        new_neutron_quota = self.networking.show_quota(openstack_project.id)['quota']
+        self.assertEqual(new_neutron_quota['floatingip'], 3)
+        actual_nova_quota = self.compute.quotas.get(openstack_project.id)
+        self.assertEqual(actual_nova_quota.__getattr__('cores'), 100)
 
     def test_reactivate_allocation(self):
         user = self.new_user()

--- a/src/coldfront_plugin_openstack/utils.py
+++ b/src/coldfront_plugin_openstack/utils.py
@@ -2,11 +2,19 @@ from coldfront.core.allocation.models import (AllocationAttribute,
                                               AllocationAttributeType)
 
 
-def add_attribute_to_allocation(allocation, attribute_type, attribute_value):
+def set_attribute_on_allocation(allocation, attribute_type, attribute_value):
     allocation_attribute_type_obj = AllocationAttributeType.objects.get(
         name=attribute_type)
-    AllocationAttribute.objects.create(
-        allocation_attribute_type=allocation_attribute_type_obj,
-        allocation=allocation,
-        value=attribute_value,
-    )
+    try:
+        attribute_obj = AllocationAttribute.objects.get(
+            allocation_attribute_type=allocation_attribute_type_obj,
+            allocation=allocation
+        )
+        attribute_obj.value = attribute_value
+        attribute_obj.save()
+    except AllocationAttribute.DoesNotExist:
+        AllocationAttribute.objects.create(
+            allocation_attribute_type=allocation_attribute_type_obj,
+            allocation=allocation,
+            value=attribute_value,
+        )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ubccr/coldfront@7dc4391c0cb54ec85ff82a0199ff0461454d5fb0#egg=coldfront
+git+https://github.com/ubccr/coldfront@2e60db247fd9a9b0d1299f1e98f1e4ef5f5c259b#egg=coldfront
 python-cinderclient  # TODO: Set version for OpenStack Clients
 python-keystoneclient
 python-memcached==1.59


### PR DESCRIPTION
Closes #1 

- Persist current quota as allocation attribute on activation
- Also adds exit on error for run_functional_tests.sh
- Also adds a conditional to installing docker-compose for when
  running on vagrant.
- Added support for floating ips
- Refactored some of the common code for setting quotas
- Refactored the testing code for quotas to be more easy to read
- Renamed and updated utils.add_allocation_attribute to
  utils.get_allocation_attribute and now it supports updating
  existing allocation attributes
- Added a receiver for allocation_change_approval to
  activate_allocation.
