### PR TITLE
Create default network when provisioning project

### DIFF
--- a/.github/workflows/test-py39-functional.yaml
+++ b/.github/workflows/test-py39-functional.yaml
@@ -42,6 +42,7 @@ jobs:
               microstack.openstack application credential create "$CREDENTIAL_NAME" -f value -c secret)
           export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID=$(
               microstack.openstack application credential show "$CREDENTIAL_NAME" -f value -c id)
+          export OPENSTACK_PUBLIC_NETWORK_ID=$(microstack.openstack network show external -f value -c id)
           export OS_AUTH_URL="https://localhost:5000"
 
           coldfront test coldfront_plugin_openstack.tests.functional

--- a/ci/run_functional_tests.sh
+++ b/ci/run_functional_tests.sh
@@ -12,6 +12,8 @@ export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_SECRET=$(
 export OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID=$(
     openstack application credential show "$credential_name" -f value -c id)
 
+export OPENSTACK_PUBLIC_NETWORK_ID=$(openstack network show public -f value -c id)
+
 source /tmp/coldfront_venv/bin/activate
 
 export DJANGO_SETTINGS_MODULE="local_settings"

--- a/src/coldfront_plugin_openstack/attributes.py
+++ b/src/coldfront_plugin_openstack/attributes.py
@@ -4,13 +4,17 @@ RESOURCE_IDP = 'OpenStack Identity Provider'
 RESOURCE_PROJECT_DOMAIN = 'OpenStack Domain for Projects'
 RESOURCE_ROLE = 'OpenStack Role for User in Project'
 RESOURCE_USER_DOMAIN = 'OpenStack Domain for Users'
+RESOURCE_DEFAULT_PUBLIC_NETWORK = 'OpenStack Public Network ID'
+RESOURCE_DEFAULT_NETWORK_CIDR = 'OpenStack Default Network CIDR'
 
 RESOURCE_ATTRIBUTES = [RESOURCE_AUTH_URL,
                        RESOURCE_FEDERATION_PROTOCOL,
                        RESOURCE_IDP,
                        RESOURCE_PROJECT_DOMAIN,
                        RESOURCE_ROLE,
-                       RESOURCE_USER_DOMAIN]
+                       RESOURCE_USER_DOMAIN,
+                       RESOURCE_DEFAULT_PUBLIC_NETWORK,
+                       RESOURCE_DEFAULT_NETWORK_CIDR]
 
 ALLOCATION_PROJECT_ID = 'OpenStack Project ID'
 ALLOCATION_PROJECT_NAME = 'OpenStack Project Name'

--- a/src/coldfront_plugin_openstack/management/commands/add_openstack_resource.py
+++ b/src/coldfront_plugin_openstack/management/commands/add_openstack_resource.py
@@ -27,13 +27,20 @@ class Command(BaseCommand):
                             help='Federation protocol (default: openid)')
         parser.add_argument('--role', type=str, default='member',
                             help='Role for user when added to project (default: member)')
+        parser.add_argumet('--public-network', type=str, default='',
+                           help='Public network ID for default networks. '
+                                'If not specified, no default network is '
+                                'created for new projects.')
+        parser.add_argumet('--network-cidr', type=str, default='192.168.0.0/24',
+                           help='CIDR for default networks. '
+                                'Ignored if no --public-network.')
 
     def handle(self, *args, **options):
         openstack, _ = Resource.objects.get_or_create(
             resource_type=ResourceType.objects.get(name='OpenStack'),
             parent_resource=None,
             name=options['name'],
-            description='OpenStack test cloud environment',
+            description='OpenStack cloud environment',
             is_available=True,
             is_public=True,
             is_allocatable=True
@@ -87,3 +94,17 @@ class Command(BaseCommand):
             resource=openstack,
             value=1
         )
+
+        if options['public_network']:
+            ResourceAttribute.objects.get_or_create(
+                resource_attribute_type=ResourceAttributeType.objects.get(
+                    name=attributes.RESOURCE_DEFAULT_PUBLIC_NETWORK),
+                resource=openstack,
+                value=options['public_network']
+            )
+            ResourceAttribute.objects.get_or_create(
+                resource_attribute_type=ResourceAttributeType.objects.get(
+                    name=attributes.RESOURCE_DEFAULT_NETWORK_CIDR),
+                resource=openstack,
+                value=options['network_cidr']
+            )

--- a/src/coldfront_plugin_openstack/tests/base.py
+++ b/src/coldfront_plugin_openstack/tests/base.py
@@ -1,8 +1,10 @@
+import os
 from os import devnull
 import sys
 import uuid
 
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from coldfront.core.allocation.models import (Allocation,
                                               AllocationStatusChoice,
@@ -102,6 +104,12 @@ class TestBase(TestCase):
                 name='quantity_default_value'),
             resource=openstack,
             value=1
+        )
+        ResourceAttribute.objects.get_or_create(
+            resource_attribute_type=ResourceAttributeType.objects.get(
+                name=attributes.RESOURCE_DEFAULT_PUBLIC_NETWORK),
+            resource=openstack,
+            value=os.getenv('OPENSTACK_PUBLIC_NETWORK_ID')
         )
 
         return openstack


### PR DESCRIPTION
- Added attribute 'OpenStack Public Network ID'
- Added attribute 'OpenStack Default Network CIDR'
- Default network DNS set to Google DNS
- Added simple test case of network created

Closes #21 