### PR TITLE
Fix indent on add_user_to_allocation

### DIFF
--- a/src/coldfront_plugin_openstack/tasks.py
+++ b/src/coldfront_plugin_openstack/tasks.py
@@ -224,8 +224,8 @@ def add_user_to_allocation(allocation_user_pk):
         if not project_id:
             raise Exception('Project not created yet!')
 
-    get_or_create_federated_user(resource, username)
-    assign_role_on_user(resource, username, project_id)
+        get_or_create_federated_user(resource, username)
+        assign_role_on_user(resource, username, project_id)
 
 
 def remove_user_from_allocation(allocation_user_pk):


### PR DESCRIPTION
The wrong indent was causing the plugin to execute code for
other resource types.

Reported by @culbert 