### PR TITLE
Use call_method on add_openstack_resource in tests

### DIFF
--- a/src/coldfront_plugin_openstack/tests/base.py
+++ b/src/coldfront_plugin_openstack/tests/base.py
@@ -43,76 +43,21 @@ class TestBase(TestCase):
 
     @staticmethod
     def new_resource(name=None, auth_url=None) -> Resource:
-        # TODO: User call_command on add_openstack_resource instead of duplicating this
         resource_name = name or uuid.uuid4().hex
 
-        Resource.objects.create(
-            resource_type=ResourceType.objects.get(name='OpenStack'),
-            parent_resource=None,
-            name=resource_name,
-            description='OpenStack test cloud environment',
-            is_available=True,
-            is_public=True,
-            is_allocatable=True
+        call_command(
+            'add_openstack_resource',
+             name=resource_name,
+             auth_url=auth_url or f'https://{resource_name}/identity/v3',
+             projects_domain='default',
+             users_domain='default',
+             idp='sso',
+             protocol='openid',
+             role='member',
+             public_network=os.getenv('OPENSTACK_PUBLIC_NETWORK_ID'),
+             network_cidr='192.168.0.0/24',
         )
-        openstack = Resource.objects.get(name=resource_name)
-
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name=attributes.RESOURCE_AUTH_URL),
-            resource=openstack,
-            value=auth_url or f'https://{resource_name}/identity/v3'
-        )
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name=attributes.RESOURCE_PROJECT_DOMAIN),
-            resource=openstack,
-            value='default'
-        )
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name=attributes.RESOURCE_USER_DOMAIN),
-            resource=openstack,
-            value='default'
-        )
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name=attributes.RESOURCE_IDP),
-            resource=openstack,
-            value='sso'
-        )
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name=attributes.RESOURCE_FEDERATION_PROTOCOL),
-            resource=openstack,
-            value='openid'
-        )
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name=attributes.RESOURCE_ROLE),
-            resource=openstack,
-            value='member'
-        )
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name='quantity_label'),
-            resource=openstack,
-            value='Units of computing to allocate to the project. 1 Unit = 1 Instance, 2 vCPU, 4G RAM'
-        )
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name='quantity_default_value'),
-            resource=openstack,
-            value=1
-        )
-        ResourceAttribute.objects.get_or_create(
-            resource_attribute_type=ResourceAttributeType.objects.get(
-                name=attributes.RESOURCE_DEFAULT_PUBLIC_NETWORK),
-            resource=openstack,
-            value=os.getenv('OPENSTACK_PUBLIC_NETWORK_ID')
-        )
-
-        return openstack
+        return Resource.objects.get(name=resource_name)
 
     def new_project(self, title=None, pi=None) -> Project:
         title = title or uuid.uuid4().hex


### PR DESCRIPTION
Rather than directly creating the Resource from the model,
use the command line interface. This should prevent breakages
in the command that happened previously by the lack of testing
for that part of the codebase.

Closes #25