### PR TITLE
Add attribute to track GPU quota

### DIFF
--- a/src/coldfront_plugin_openstack/attributes.py
+++ b/src/coldfront_plugin_openstack/attributes.py
@@ -33,11 +33,14 @@ QUOTA_FLOATING_IPS = 'OpenStack Floating IP Quota'
 
 QUOTA_OBJECT_GB = 'OpenStack Swift Quota in Gigabytes'
 
+QUOTA_GPU = 'Quota for GPUs'
+
 ALLOCATION_QUOTA_ATTRIBUTES = [QUOTA_INSTANCES,
                                QUOTA_RAM,
                                QUOTA_VCPU,
                                QUOTA_VOLUMES,
                                QUOTA_VOLUMES_GB,
                                QUOTA_FLOATING_IPS,
-                               QUOTA_OBJECT_GB]
+                               QUOTA_OBJECT_GB,
+                               QUOTA_GPU]
 

--- a/src/coldfront_plugin_openstack/tasks.py
+++ b/src/coldfront_plugin_openstack/tasks.py
@@ -22,6 +22,7 @@ UNIT_QUOTA_MULTIPLIERS = {
         attributes.QUOTA_VOLUMES_GB: 100,
         attributes.QUOTA_FLOATING_IPS: 0,
         attributes.QUOTA_OBJECT_GB: 1,
+        attributes.QUOTA_GPU: 0,
     }
 }
 
@@ -31,6 +32,7 @@ UNIT_QUOTA_MULTIPLIERS = {
 STATIC_QUOTA = {
     'openstack': {
         attributes.QUOTA_FLOATING_IPS: 2,
+        attributes.QUOTA_GPU: 0,
     }
 }
 


### PR DESCRIPTION
Adds an attribute to track GPU quota. Does not apply the quota to any service, just tracks it.