### PR TITLE
Annotations

### DIFF
--- a/src/coldfront_plugin_openstack/openshift.py
+++ b/src/coldfront_plugin_openstack/openshift.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import logging
 import os
 import requests
 from requests.auth import HTTPBasicAuth
@@ -134,8 +135,13 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
 
     def _create_project(self, project_name, project_id):
         url = f"{self.auth_url}/projects/{project_id}"
-        payload = {"displayName": project_name}
-        r = self.session.put(url, data=json.dumps(payload))
+        headers = {"Content-type": "application/json"}
+        annotations = {"cf_project_id": str(self.allocation.project_id),
+                       "cf_pi": self.allocation.project.pi.username}
+
+        payload = {"displayName": project_name,
+                   "annotations": annotations}
+        r = self.session.put(url, data=json.dumps(payload), headers=headers)
         self.check_response(r)
 
     def _get_role(self, username, project_id):


### PR DESCRIPTION
Add pi information as annotation metadata for openshift resources. This will be useful for later metric data consumption in xdmod.