### PR TITLE
Implement get_quota and initial implementation of validate_allocations

### DIFF
--- a/src/coldfront_plugin_openstack/base.py
+++ b/src/coldfront_plugin_openstack/base.py
@@ -51,6 +51,10 @@ class ResourceAllocator(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def get_quota(self, project_id):
+        pass
+
+    @abc.abstractmethod
     def create_federated_user(self, unique_id):
         pass
 

--- a/src/coldfront_plugin_openstack/management/commands/validate_allocations.py
+++ b/src/coldfront_plugin_openstack/management/commands/validate_allocations.py
@@ -1,0 +1,70 @@
+import logging
+
+from coldfront_plugin_openstack import attributes
+from coldfront_plugin_openstack import openstack
+
+from django.core.management.base import BaseCommand
+from coldfront.core.resource.models import (Resource,
+                                            ResourceType)
+from coldfront.core.allocation.models import (Allocation,
+                                              AllocationStatusChoice)
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Validates quotas and users in resource allocations.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--apply', action='store_true',
+                            help='Apply expected state if validation fails.')
+
+    def handle(self, *args, **options):
+        supported_resources = Resource.objects.filter(
+            resource_type=ResourceType.objects.get(
+                name='OpenStack'
+            )
+        )
+        allocations = Allocation.objects.filter(
+            resources__in=supported_resources,
+            status=AllocationStatusChoice.objects.get(name='Active')
+        )
+        for allocation in allocations:
+            allocation_str = f'{allocation.pk} of project "{allocation.project.title}"'
+            msg = f'Starting resource validation for allocation {allocation_str}.'
+            logger.debug(msg)
+
+            failed_validation = False
+
+            allocator = openstack.OpenStackResourceAllocator(
+                allocation.resources.first(),
+                allocation
+            )
+            quota = allocator.get_quota(
+                allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+            )
+            for attr in attributes.ALLOCATION_QUOTA_ATTRIBUTES:
+                if 'OpenStack' in attr:
+                    expected_value = allocation.get_attribute(attr)
+                    if expected_value is None:
+                        msg = f'Attribute "{attr}" expected on allocation {allocation_str} but not set.'
+                        logger.warning(msg)
+                    else:
+                        key = openstack.QUOTA_KEY_MAPPING_ALL_KEYS.get(attr, None)
+                        if not key:
+                            # Note(knikolla): Some attributes are only maintained
+                            # for bookkeeping purposes and do not have a
+                            # corresponding quota set on the service.
+                            continue
+                        elif not (value := quota.get(key, None)) == expected_value:
+                            failed_validation = True
+                            msg = (f'Value for quota for {attr} = {value} does not match expected'
+                                   f' value of {expected_value} on allocation {allocation_str}')
+                            logger.warning(msg)
+
+            if failed_validation and options['apply']:
+                allocator.set_quota(
+                    allocation.get_attribute(attributes.ALLOCATION_PROJECT_ID)
+                )
+                logger.warning(f'Quota for allocation {allocation_str} was out of date. Reapplied!')

--- a/src/coldfront_plugin_openstack/openshift.py
+++ b/src/coldfront_plugin_openstack/openshift.py
@@ -81,6 +81,11 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
         r = self.session.put(url, data=json.dumps({'Quota': payload}))
         self.check_response(r)
 
+    def get_quota(self, project_id):
+        url = f"{self.auth_url}/projects/{project_id}/quota"
+        r = self.session.get(url)
+        return self.check_response(r)
+
     def create_project_defaults(self, project_id):
         pass
 
@@ -153,9 +158,4 @@ class OpenShiftResourceAllocator(base.ResourceAllocator):
     def _delete_user(self, username):
         url = f"{self.auth_url}/users/{username}"
         r = self.session.delete(url)
-        return self.check_response(r)
-
-    def _get_quota(self, project_id):
-        url = f"{self.auth_url}/projects/{project_id}/quota"
-        r = self.session.get(url)
         return self.check_response(r)

--- a/src/coldfront_plugin_openstack/tests/base.py
+++ b/src/coldfront_plugin_openstack/tests/base.py
@@ -93,7 +93,7 @@ class TestBase(TestCase):
             justification='a justification for testing data',
             quantity=quantity,
             status=AllocationStatusChoice.objects.get(
-                name='New')
+                name='Active')
         )
         allocation.resources.add(resource)
         return allocation

--- a/src/coldfront_plugin_openstack/tests/functional/openshift/test_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/functional/openshift/test_allocation.py
@@ -98,7 +98,7 @@ class TestAllocation(base.TestBase):
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_MEMORY), 2 * 2048)
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_EPHEMERAL_STORAGE_GB), 2 * 5)
 
-        quota = allocator._get_quota(project_id)['Quota']
+        quota = allocator.get_quota(project_id)['Quota']
         quota = {k: v for k, v in quota.items() if v is not None}
         # The return value will update to the most relevant unit, so
         # 4000m cores becomes 4 and 4096Mi becomes 4Gi
@@ -122,7 +122,7 @@ class TestAllocation(base.TestBase):
 
         self.assertEqual(allocation.get_attribute(attributes.QUOTA_LIMITS_CPU), 4)
 
-        quota = allocator._get_quota(project_id)['Quota']
+        quota = allocator.get_quota(project_id)['Quota']
 
         # https://github.com/CCI-MOC/openshift-acct-mgt
         quota = {k: v for k, v in quota.items() if v is not None}
@@ -140,7 +140,7 @@ class TestAllocation(base.TestBase):
         tasks.activate_allocation(allocation.pk)
         allocation.refresh_from_db()
 
-        quota = allocator._get_quota(project_id)['Quota']
+        quota = allocator.get_quota(project_id)['Quota']
         quota = {k: v for k, v in quota.items() if v is not None}
         # The return value will update to the most relevant unit, so
         # 4000m cores becomes 4 and 4096Mi becomes 4Gi

--- a/src/coldfront_plugin_openstack/tests/functional/openstack/test_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/functional/openstack/test_allocation.py
@@ -92,6 +92,18 @@ class TestAllocation(base.TestBase):
         for k, v in expected_neutron_quota.items():
             self.assertEqual(actual_neutron_quota.get(k), v)
 
+        # Validate get_quota
+        expected_quota = {
+            'instances': 1,
+            'cores': 2,
+            'ram': 4096,
+            'volumes': 2,
+            'gigabytes': 100,
+            'floatingip': 2,
+            'x-account-meta-quota-bytes': 1000000000,
+        }
+        self.assertEqual(expected_quota, allocator.get_quota(openstack_project.id))
+
         # Check correct attributes
         for attr in attributes.ALLOCATION_QUOTA_ATTRIBUTES:
             if 'OpenStack' in attr:

--- a/src/coldfront_plugin_openstack/tests/functional/openstack/test_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/functional/openstack/test_allocation.py
@@ -101,7 +101,10 @@ class TestAllocation(base.TestBase):
             'floatingip': 2,
             'x-account-meta-quota-bytes': 1,
         }
-        self.assertEqual(expected_quota, allocator.get_quota(openstack_project.id))
+        resulting_quota = allocator.get_quota(openstack_project.id)
+        if 'x-account-meta-quota-bytes' not in resulting_quota.keys():
+            expected_quota.pop('x-account-meta-quota-bytes')
+        self.assertEqual(expected_quota, resulting_quota)
 
         # Check correct attributes
         for attr in attributes.ALLOCATION_QUOTA_ATTRIBUTES:

--- a/src/coldfront_plugin_openstack/tests/functional/openstack/test_allocation.py
+++ b/src/coldfront_plugin_openstack/tests/functional/openstack/test_allocation.py
@@ -4,8 +4,7 @@ import unittest
 from coldfront_plugin_openstack import attributes, openstack, tasks, utils
 from coldfront_plugin_openstack.tests import base
 
-from keystoneauth1.identity import v3
-from keystoneauth1 import session
+from django.core.management import call_command
 from keystoneclient.v3 import client
 from cinderclient import client as cinderclient
 from neutronclient.v2_0 import client as neutronclient
@@ -100,7 +99,7 @@ class TestAllocation(base.TestBase):
             'volumes': 2,
             'gigabytes': 100,
             'floatingip': 2,
-            'x-account-meta-quota-bytes': 1000000000,
+            'x-account-meta-quota-bytes': 1,
         }
         self.assertEqual(expected_quota, allocator.get_quota(openstack_project.id))
 
@@ -180,6 +179,20 @@ class TestAllocation(base.TestBase):
         self.assertEqual(new_neutron_quota['floatingip'], 3)
         actual_nova_quota = self.compute.quotas.get(openstack_project.id)
         self.assertEqual(actual_nova_quota.__getattr__('cores'), 100)
+
+        # Change allocation attributes for floating ips and cores again
+        utils.set_attribute_on_allocation(allocation, attributes.QUOTA_FLOATING_IPS, 6)
+        utils.set_attribute_on_allocation(allocation, attributes.QUOTA_VCPU, 200)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_FLOATING_IPS), 6)
+        self.assertEqual(allocation.get_attribute(attributes.QUOTA_VCPU), 200)
+
+        call_command('validate_allocations', apply=True)
+
+        # Recheck neutron quota after attribute change
+        new_neutron_quota = self.networking.show_quota(openstack_project.id)['quota']
+        self.assertEqual(new_neutron_quota['floatingip'], 6)
+        actual_nova_quota = self.compute.quotas.get(openstack_project.id)
+        self.assertEqual(actual_nova_quota.__getattr__('cores'), 200)
 
     def test_reactivate_allocation(self):
         user = self.new_user()


### PR DESCRIPTION
- The ResourceAllocator base class now defines get_quota and the OpenStack
resource allocator implements the method.

- Currently limited to OpenStack resources, the `validate_allocations` command
checks that the output of get_quota on an allocation, matches the value of the quota
attributes.